### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,9 @@ on:
                 required: false
                 default: '20.5'
 
+permissions:
+  contents: read
+
 jobs:
   prepare-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BobKerns/hou-aibridge/security/code-scanning/3](https://github.com/BobKerns/hou-aibridge/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves reading repository contents and does not appear to require write permissions, we will set `contents: read` at the workflow level. This will apply the minimal required permissions to all jobs in the workflow unless overridden by job-specific `permissions` blocks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
