### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,9 @@ on:
                 required: false
                 default: '20.5'
 
+permissions:
+  contents: read
+
 jobs:
   prepare-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BobKerns/hou-aibridge/security/code-scanning/1](https://github.com/BobKerns/hou-aibridge/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to the minimum required for the workflow. Based on the workflow's actions, it only needs to read repository contents, so we will set `contents: read`. This change ensures that the workflow cannot perform unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
