### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -7,6 +7,8 @@ on:
     - created
     - published
 
+permissions:
+  contents: write
 
 jobs:
   build-extension:


### PR DESCRIPTION
Potential fix for [https://github.com/BobKerns/hou-aibridge/security/code-scanning/2](https://github.com/BobKerns/hou-aibridge/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required. Based on the workflow's steps, the following permissions are likely needed:
- `contents: read` for accessing repository contents.
- `contents: write` for the `pnpm run deploy` step, which likely modifies repository contents during publishing.

We will add the `permissions` block at the root level to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
