### PR TITLE
markserv, which brings in a DOS-vulnerable library is dev-only

### DIFF
--- a/zabob-modules/package.json
+++ b/zabob-modules/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "aibridge-zabob-modules",
+    "name": "zabob-modules",
     "version": "0.1.0",
-    "description": "Scripts for aibridge",
+    "description": "Core tools for the Zabob AIBridge",
     "main": "index.js",
     "scripts": {
         "build": "tsc -p tsconfig.build.json",
@@ -23,7 +23,7 @@
     "homepage": "https://github.com/BobKerns/hou-aibridge?tab=readme-ov-file#zabob-the-ai-bridge-to-houdini-sfx",
     "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
     "license": "MIT",
-    "dependencies": {
+    "devDependencies": {
         "markserv": "^1.17.4"
     }
 }

--- a/zabob-modules/pnpm-lock.yaml
+++ b/zabob-modules/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 importers:
 
   .:
-    dependencies:
+    devDependencies:
       markserv:
         specifier: ^1.17.4
         version: 1.17.4
@@ -63,8 +63,8 @@ packages:
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
-  '@types/node@22.15.19':
-    resolution: {integrity: sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==}
+  '@types/node@22.15.21':
+    resolution: {integrity: sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -1461,11 +1461,11 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 22.15.19
+      '@types/node': 22.15.21
 
   '@types/minimist@1.2.5': {}
 
-  '@types/node@22.15.19':
+  '@types/node@22.15.21':
     dependencies:
       undici-types: 6.21.0
 
@@ -1473,7 +1473,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 22.15.19
+      '@types/node': 22.15.21
 
   '@xmldom/xmldom@0.8.10': {}
 


### PR DESCRIPTION
The Dependabot alert, has no impact, as the server is only run locally during development, on local content.