### PR TITLE
Disable spurious CodeQL warning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+queries:
+  - exclude:
+      id: py/bind-socket-all-network-interfaces

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,3 +1,6 @@
-queries:
+query-filters:
   - exclude:
+      # Generates spurious warnings about the check for free ports.
+      # This intentionally momentarily binds to all network interfaces
+      # but does not enable connections.
       id: py/bind-socket-all-network-interfaces

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,6 +71,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
+        config-file: .github/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # If you wish to specify custom queries, you can do so here or in a config file.


### PR DESCRIPTION
py/bind-socket-all-network-interfaces is triggering on the check for a given port number being in use on any interface. It can't tell that it's not accepting connections, merely checking port availability.